### PR TITLE
Convert the huge readme to read-the-docs pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vagrant
 *.bak
 Vagrantfile.local
+.idea

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enrise Basebox
 
-[![Documentation Status](https://readthedocs.org/projects/enrise-basebox/badge/?version=latest)](http://enrise-basebox.readthedocs.org/en/latest/?badge=latest)
+[![Documentation](https://readthedocs.org/projects/enrise-basebox/badge/?version=master)](http://enrise-basebox.readthedocs.org/)
 
 This box serves as a standardized version of Vagrant box and should be used for new projects.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Enrise Basebox
 
+[![Documentation Status](https://readthedocs.org/projects/enrise-basebox/badge/?version=latest)](http://enrise-basebox.readthedocs.org/en/latest/?badge=latest)
+
 This box serves as a standardized version of Vagrant box and should be used for new projects.
 
 Provisioning is done using [Saltstack](http://saltstack.org), which uses various default

--- a/docs/configure-salt.md
+++ b/docs/configure-salt.md
@@ -1,0 +1,129 @@
+# Salt
+
+By default Salt will install Zendserver (7.0) + Nginx once you have created vhosts. If you specify databases, it
+will install MySQL-server as well.
+
+For this a dist structure has been provided which is the `salt.dist` folder located in `dev/basebox`. This will
+need to be copied to `./dev/salt`:
+
+```sh
+cp -r dev/basebox/salt.dist dev/salt
+```
+
+> **Note:** This path is configurable in `Vagrantfile.local` (parameter: $salt_custom_path)
+
+The Salt fileserver will look for the files configured in the topfile.
+For this is will search in both the "core" module as customizations.
+
+The priority of loading is:
+
+1. Custom files
+1. Core files
+
+Salt stops searching as soon as it has reached a matching file.
+This may or may not be desirable so be careful with the naming of your states and files.
+
+If you want to add custom states or pillars, you'll have to manage a custom `top.sls`.
+This will completely override the defaults.
+
+> For this its also required that your topfile includes `core` and `vhosting`.
+
+## Custom vhosts
+
+The `vhosts.sls` state will be loaded. In the core, this is an empty state which means no vhosts or databases
+will be available.
+
+In order to get this to work you'll have to rename distributed vhost file:
+
+```sh
+mv dev/salt/pillars/vhosts.sls.dist dev/salt/pillars/vhosts.sls
+```
+
+and edit it accordingly. A basic vhost could look like this:
+
+```yaml
+vhosting:
+  users:
+    projectname:
+      deploy_structure: True
+      vhost:
+        projectname-dev.enrise.com:
+          webroot_public: True
+      mysql_database:
+        projectname:
+          password: changeme
+```
+
+This will create paths (using default deploy structure), install the webserver, creates a vhost and enables
+it and creates a MySQL user/db pair.
+
+A description of options for the vhosting is available in the
+[vhosting formula documentation](https://github.com/enrise/vhosting-formula).
+
+> **Note:**: If you do not specify vhosts, no webserver will be installed. The same applies on mysql_database:
+> no databases = no MySQL installed.
+
+If you use the config as above it will create a folder structure:
+
+```sh
+/srv/http/projectname/hosts/projectname-dev.enrise.net
+```
+
+This folder (used in the vhost) contains a symlink to `../current/public`.
+The only thing that remains is a symlink:
+
+```sh
+cd /srv/http/projectname
+ln -s /vagrant current
+```
+
+## Custom webserver
+
+Default behavior (e.g. Zendserver+Nginx) can be overruled by creating a file in `salt/pillars/defaults` with
+just the information you want to override or extend.
+
+For instance, the default is Zendserver + Nginx:
+
+```yaml
+# Zendserver
+zendserver:
+  version:
+    zend: 7.0
+  webserver: nginx
+  bootstrap: False
+```
+
+But you want Apache2 (on Ubuntu so its 2.4, requiring a special ZS Repo).
+Create `salt/pillars/defaults/zendserver.sls` and set the changed value:
+
+```yaml
+zendserver:
+  webserver: apache2
+  version:
+    apache: 2.4
+```
+
+> **Note:** When changing webservers and using the `vhosting` module, do not forget to override its
+> configuration as well (in `defaults/vhosting.sls`)
+
+The custom file will always take precedence.
+
+## Adding formulas
+
+Its recommended to use git submodules.
+Add a submodule in `salt/formulas` and symlink the folder (in its `name/name` form) into the states folder.
+This may also be used to get newer versions of formulas since the fileserver will automatically take the
+custom one over the core.
+
+## Customizing pillars
+
+Certain formulas may require specific pillars to change their default behavior.
+For this you should use the `custom.sls` file located in the pillar folder.
+
+## Customizing states
+
+If you want to extend the basebox, e.g. you have added a formula and want to use it you can customize
+the `custom` state. The `custom.sls` file is located in the `states` folder and allows you to specify
+your own Salt states.
+
+You can use this to include formulas or add in specific requirements for your box.

--- a/docs/configure-vagrant.md
+++ b/docs/configure-vagrant.md
@@ -1,0 +1,19 @@
+# Vagrant
+
+In order to benefit from base updates you should symlink the Vagrantfile to the root of your project:
+
+```sh
+ln -s dev/basebox/Vagrantfile .
+```
+
+You could also copy this file instead of symlinking, but this would require a manual action to update which
+is not recommended.
+
+The configuration of the Vagrantbox should always be done in `Vagrantfile.local`.
+A default is provided but should be copied/renamed to the root of your project:
+
+```sh
+cp dev/basebox/Vagrantfile.local.dist Vagrantfile.local
+```
+
+You should change the parameters (e.g. ip, hostname) to match your project before booting.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,3 @@ This box provides a default web-stack (ZendServer 7.0 + Nginx + MariaDB) using t
 The box should be build on a Debian or Ubuntu VM.
 
 Further requirements (e.g. Node, Postgres, Composer etc) can be added by the user of this box.
-
-For more information and installation details check
-[the documentation](http://enrise-basebox.readthedocs.org/en/latest/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Enrise Basebox
 
-[![Documentation Status](https://readthedocs.org/projects/enrise-basebox/badge/?version=latest)](http://enrise-basebox.readthedocs.org/en/latest/?badge=latest)
+[![Documentation](https://readthedocs.org/projects/enrise-basebox/badge/?version=master)](http://enrise-basebox.readthedocs.org/)
 
 This box serves as a standardized version of Vagrant box and should be used for new projects.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 # Enrise Basebox
 
+[![Documentation Status](https://readthedocs.org/projects/enrise-basebox/badge/?version=latest)](http://enrise-basebox.readthedocs.org/en/latest/?badge=latest)
+
 This box serves as a standardized version of Vagrant box and should be used for new projects.
 
 Provisioning is done using [Saltstack](http://saltstack.org), which uses various default

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,19 @@
+# Installing
+
+Add the basebox as a Git submodule to your project from the root of your project:
+
+```sh
+git submodule add git@github.com:enrise/basebox dev/basebox
+```
+
+> **Note**: You may use a custom path to check it out to, but this value must also be set accordingly in
+`Vagrantfile.local` (parameter: $basebox_path)
+
+Once the basebox has been added as a submodule to your project, it should pull in its own dependencies. To do so,
+instruct git to update in the submodules:
+
+```sh
+git submodule sync && git submodule update --init --recursive
+```
+
+Once this has been completed you have the basebox and its dependencies and can proceed with the configuration.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -1,0 +1,4 @@
+# Issues
+
+For a list of known issues, please see the [GitHub project issue tracker](https://github.com/Enrise/Basebox/issues).
+If you have an issue with the Basebox, don't hesitate to let us know there, and we will do our best to help you.

--- a/docs/sending-mail.md
+++ b/docs/sending-mail.md
@@ -1,0 +1,10 @@
+# Sending mail
+
+The Basebox comes with [Mailhog](https://github.com/mailhog/Mailhog/), which catches mails that are being sent via
+the system's sendmail. Mailhog can be found on HTTP port 8025 by browsing to `http://your.project.box:8025`,
+and will show an overview of the sent mails.
+
+Releasing the mail, thus delivering it for real, can be done as follows:
+
+1. Click on the mail you want to release
+2. In the mail detail page, click on the release button in the top bar

--- a/docs/standard-packages.md
+++ b/docs/standard-packages.md
@@ -1,0 +1,4 @@
+# Standard packages
+
+The Basebox contains a variety of standard installed packages, which are typically used by developers / devops.
+A list of what packages are installed by default can be seen by viewing `dev/salt/states/packages/init.sls`.

--- a/docs/starting.md
+++ b/docs/starting.md
@@ -1,0 +1,18 @@
+## Starting the VM
+
+Ready, let's start!
+
+Execute this in your shell:
+
+```sh
+vagrant up
+```
+
+The first boot takes some time.
+The box will install Salt and runs (if enabled) the highstate which provisions the machine.
+
+Once it has been completed, the box can be accessed:
+
+```sh
+vagrant ssh
+```

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1,0 +1,27 @@
+# Updating the basebox
+
+Its expected that the Basebox will be extended and improved from time to time.
+
+## Automatically
+
+Execute the following command from your git repo on your development machine:
+
+```sh
+./dev/basebox/update.sh
+```
+
+This will execute everything listed under the manual steps below but will automatically find the actual checkout path
+based on the settings in `Vagrantfile.local`.
+
+## Manually
+
+To pull in the changes you'll have to update the git submodule of the basebox:
+
+```sh
+cd dev/basebox
+git pull origin master
+git submodule sync  && git submodule update --init --recursive
+```
+
+> **Hint**: If you have the `vagrant-triggers` plugin installed it will automatically check and notify you if there are
+> updates upon the following tasks: up, resume and provision.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: Enrise Basebox
+theme: readthedocs
+pages:
+  - [index.md, Home]
+  - [installation.md, Installation]
+  - [configure-vagrant.md, Configure Vagrant]
+  - [configure-salt.md, Configure Salt]
+  - [starting.md, Starting the VM]
+  - [updating.md, Updating Basebox]
+  - [standard-packages.md, Standard packages]
+  - [sending-mail.md, Sending mail]
+  - [issues.md, Open issues]


### PR DESCRIPTION
### What

This PR transforms the huge-ass readme into a read-the-docs setup.
### How to test
1. See that all text that was in the readme is present in seperate pages
2. See that read-the-docs is configured in the proof section
3. https://readthedocs.org/projects/enrise-basebox/
