### PR TITLE
Add support for custom mountpoints

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,7 @@ $mount_options_rsync      ||= []
 $vm_hostname              ||= "unconfigured.vagrant.box"
 $vm_box                   ||= "ubuntu/trusty64"
 $vm_aliases               ||= nil
+$vm_mounts                ||= {"." => "/vagrant"}
 $vm_ip                    ||= "192.168.56.100"
 $basebox_path             ||= "dev/basebox"
 $salt_highstate           ||= true
@@ -39,7 +40,9 @@ Vagrant.configure("2") do |config|
 
   # Mounts
   if $mount_type == "virtualbox"
-    config.vm.synced_folder ".", "/vagrant", owner: "vagrant", group: "vagrant", type: "virtualbox", mount_options: $mount_options_virtualbox
+    $vm_mounts.each do |source_path, target_path|
+      config.vm.synced_folder source_path, target_path, owner: "vagrant", group: "vagrant", type: "virtualbox", mount_options: $mount_options_virtualbox
+    end
     config.vm.synced_folder $basebox_path + "/salt", "/srv/salt/base", type: "virtualbox"
     if File.exists?($salt_custom_path)
       config.vm.synced_folder $salt_custom_path, "/srv/salt/custom", type: "virtualbox"
@@ -47,7 +50,10 @@ Vagrant.configure("2") do |config|
   end
 
   if $mount_type == "nfs"
-    config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: $mount_options_nfs
+    $vm_mounts.each do |source_path, target_path|
+      config.vm.synced_folder source_path, target_path, type: "nfs", mount_options: $mount_options_nfs
+    end
+
     config.vm.synced_folder $basebox_path + "/salt", "/srv/salt/base", type: "nfs"
     if File.exists?($salt_custom_path)
       config.vm.synced_folder $salt_custom_path, "/srv/salt/custom", type: "nfs"

--- a/Vagrantfile.local.dist
+++ b/Vagrantfile.local.dist
@@ -6,6 +6,12 @@ $vm_box      = "ubuntu/trusty64"
 # Optional aliases to set (requires vagrant-hostsupdater plugin)
 # $vm_aliases  = ["alias1.nl", "alias2.com"]
 
+# Optional: Override synced_folders that are defined (default: {"." => "/vagrant"})
+# $vm_mounts = {
+#   "." => "/srv/http/app-one/current",
+#   "../app-two" => "/srv/http/app-two/current"
+# }
+
 # Define how much memory you want to assign to the VM
 # $vm_memory = 1024
 # $vm_cpus   = 1


### PR DESCRIPTION
The vhosting formula makes it easy to host multiple projects in one vagrant box, and this config extension integrates that in the Basebox.
An example of how it works is in the Vagrantfile.local.dist file.
