### PR TITLE
Introduce linked clone support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,6 +67,7 @@ Vagrant.configure('2') do |config|
   end
 
   config.vm.provider :virtualbox do |v|
+    v.linked_clone = true if Vagrant::VERSION =~ /^1.8/
     v.customize [
       'modifyvm', :id,
       '--natdnshostresolver1', 'on',

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@
 # or override these values in a Vagrantfile.local.
 $vm_memory                ||= 1024
 $vm_cpus                  ||= 1
+$vm_linked_clone          ||= true
 $mount_type               ||= 'virtualbox'
 $mount_options_virtualbox ||= ['dmode=777', 'fmode=777']
 $mount_options_nfs        ||= ['actimeo=2']
@@ -67,7 +68,7 @@ Vagrant.configure('2') do |config|
   end
 
   config.vm.provider :virtualbox do |v|
-    v.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+    v.linked_clone = $vm_linked_clone if Vagrant::VERSION =~ /^1.8/
     v.customize [
       'modifyvm', :id,
       '--natdnshostresolver1', 'on',

--- a/Vagrantfile.local.dist
+++ b/Vagrantfile.local.dist
@@ -17,6 +17,8 @@ $vm_box      = 'ubuntu/trusty64'
 # Define how much memory you want to assign to the VM
 # $vm_memory = 1024
 # $vm_cpus   = 1
+# Use 1 basebox on which delta's are applied to save diskspace (vbox >1.8)
+# $vm_linked_clone = true
 
 # Select the type of mounts to use. This can either be vboxfs, nfs, or rsync.
 # The default is virtualbox.


### PR DESCRIPTION
Most boxes build of the same base image. This PR starts reusing that base image, instead of copying it over and over to newly generated boxes to save diskspace. See https://www.vagrantup.com/docs/virtualbox/configuration.html