### PR TITLE
Fixed an issue with Libvirt on Ubuntu 17.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,6 +81,7 @@ Vagrant.configure('2') do |config|
   config.vm.provider :libvirt do |v|
     v.memory = $vm_memory
     v.cpus = $vm_cpus
+    v.cpu_mode = 'host-passthrough'
   end
 
   # Add aliases to the hosts-file.


### PR DESCRIPTION
## What
After upgrading to Ubuntu 17.04, I ran into [this Libvirt bug](https://github.com/vagrant-libvirt/vagrant-libvirt/issues/667) which basically explained that from the Vagrant file, we should inject the right CPU info so that the box would boot.

Tested on both Ubuntu 17.04 and Fedora 25 which does not (yet?) require this fix, both worked fine.

## Todo
- [x] Test on Fedora Workstation 25 with libvirtd (2.2.1)
- [x] Test on Ubuntu 17.04 with libvirtd 2.5.0
- [ ] Test on Ubuntu 16.10 with libvirtd 2.1.0 (Nobody available to test this so nobody is using this @ Enrise)
- [x] Test on Ubuntu 16.04 with libvirtd 1.3.1
