### PR TITLE
Add replacement for deprecated 'vagrant-triggers' plugin

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -105,7 +105,7 @@ Vagrant.configure('2') do |config|
     end
   end
 
-  # Check if vagrant-triggers is available for update checks
+  # Check if vagrant-triggers is available for update checks (for Vagrant < 2.1.0)
   if Vagrant.has_plugin?('vagrant-triggers')
     {
       [:up, :resume, :provision] => $basebox_path + '/check_update.sh'
@@ -114,6 +114,12 @@ Vagrant.configure('2') do |config|
         run trigger.to_s
       end
     end
+  end
+
+  # Do update checks natively if Vagrant >= 2.1.0 is being used
+  if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('2.1.0')
+    config.trigger.before :up, :resume, :provision,
+      run: {path: $basebox_path + '/check_update.sh'}
   end
 
   config.vm.post_up_message = <<MSG

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -23,5 +23,5 @@ git pull origin master
 git submodule sync  && git submodule update --init --recursive
 ```
 
-> **Hint**: If you have the `vagrant-triggers` plugin installed it will automatically check and notify you if there are
+> **Hint**: If you have the `vagrant-triggers` plugin installed (only required for Vagrant < 2.1.0) it will automatically check and notify you if there are
 > updates upon the following tasks: up, resume and provision.


### PR DESCRIPTION
`vagrant-triggers` is integrated into Vagrant 2.1.0. This PR adds the check using the new syntax while keeping the old (since it explicitly checks whether the plugin exists)

### Needs testing on
- [x] Vagrant < 2.1.0 Linux
- [x] Vagrant < 2.1.0 macOS
- [ ] Vagrant < 2.1.0 Windows
- [X] Vagrant >= 2.1.0 Linux
- [ ] Vagrant >= 2.1.0 Windows
- [x] Vagrant >= 2.1.0 macOS