### PR TITLE
Modernize basebox base / examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![Documentation](https://readthedocs.org/projects/enrise-basebox/badge/?version=master)](https://enrise-basebox.readthedocs.io/)
 [![Travis branch](https://img.shields.io/travis/Enrise/Basebox/master.svg?style=flat-square)](https://travis-ci.org/Enrise/Basebox)
 
-This box serves as a standardized version of Vagrant box and should be used for new projects.
+This box serves as a standardized version of Vagrant box and could be used to provide a standardized base for new projects.
 
 Provisioning is done using [Saltstack](http://saltstack.org), which uses various default
 [Saltstack-formulas](https://github.com/saltstack-formulas) and
 [custom Enrise formulas](https://github.com/enrise/?query=formula) to provide featurepacks.
 
-This box provides a default web-stack (ZendServer 7.0 + Nginx + MariaDB) using the
+This box provides a default web-stack (Nginx + PHP + MariaDB) using the
 [enrise/vhosting-formula](https://github.com/enrise/vhosting-formula) formula.
 The box should be built on a Debian or Ubuntu VM.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ $salt_custom_path         ||= 'dev/salt'
 $salt_log_level           ||= 'info'
 $salt_verbose             ||= true
 $salt_version             ||= 'stable'
-$salt_bootstrap_options   ||= '-P -X'
+$salt_bootstrap_options   ||= '-P -X -x python3.6'
 $salt_install_args        ||= ''
 
 # Include Vagrantfile.local if it exists to overwrite the variables.

--- a/Vagrantfile.local.dist
+++ b/Vagrantfile.local.dist
@@ -2,7 +2,7 @@
 # See the documentation for further details: http://enri.se/basebox-docs
 $vm_hostname = 'my.vagrant.box'
 $vm_ip       = '192.168.56.123'
-$vm_box      = 'ubuntu/trusty64'
+$vm_box      = 'bento/ubuntu-18.04'
 
 # Optional aliases to set (requires vagrant-hostsupdater plugin)
 # $vm_aliases  = ['alias1.nl', 'alias2.com']

--- a/Vagrantfile.local.dist
+++ b/Vagrantfile.local.dist
@@ -28,7 +28,7 @@ $vm_box      = 'bento/ubuntu-18.04'
 # Uncomment the correct line below and modify as needed.
 # To mount without mount options, simply use nil.
 # $mount_options_virtualbox = ['dmode=777', 'fmode=777']
-# $mount_options_nfs    = ['rw', 'vers=3', 'tcp', 'fsc', 'actimeo=2']
+# $mount_options_nfs    = ['rw', 'vers=3', 'tcp', 'fsc', 'actimeo=2', 'nolock']
 # $mount_options_rsync  = []
 
 # If the basebox is located somewhere else it can be entered here.

--- a/Vagrantfile.local.dist
+++ b/Vagrantfile.local.dist
@@ -55,5 +55,5 @@ $vm_box      = 'bento/ubuntu-18.04'
 
 # Set the Salt bootstrap & install script options
 # See http://enri.se/salt-bootstrap-docs for available flags & options
-# $salt_bootstrap_options = '-P -X'
+# $salt_bootstrap_options = '-P -X -x python3.6'
 # $salt_install_args = ''

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,13 +2,13 @@
 
 [![Documentation](https://readthedocs.org/projects/enrise-basebox/badge/?version=master)](http://enrise-basebox.readthedocs.org/)
 
-This box serves as a standardized version of Vagrant box and should be used for new projects.
+This box serves as a standardized version of Vagrant box and could be used to provide a standardized base for new projects.
 
 Provisioning is done using [Saltstack](http://saltstack.org), which uses various default
 [Saltstack-formulas](https://github.com/saltstack-formulas) and
 [custom Enrise formulas](https://github.com/enrise/?query=formula) to provide featurepacks.
 
-This box provides a default web-stack (ZendServer 7.0 + Nginx + MariaDB) using the
+This box provides a default web-stack (Nginx + PHP + MariaDB) using the
 [enrise/vhosting-formula](https://github.com/enrise/vhosting-formula) formula.
 The box should be built on a Debian or Ubuntu VM.
 

--- a/salt.dist/pillars/custom.sls.dist
+++ b/salt.dist/pillars/custom.sls.dist
@@ -1,0 +1,22 @@
+{%- set php_versions = ['7.2', '7.3'] %}
+vhosting:
+  server:
+    webserver: nginx
+    webserver_edition: vanilla
+
+phpfpm:
+  php_versions:
+  {% for version in php_versions %}
+    - '{{version}}'
+  {%- endfor %}
+  modules:
+  {% for version in php_versions %}
+    - php{{version}}-curl
+    - php{{version}}-gd
+    - php{{version}}-intl
+    - php{{version}}-json
+    - php{{version}}-mbstring
+    - php{{version}}-mysql
+    - php{{version}}-xml
+    - php{{version}}-zip
+  {%- endfor %}

--- a/salt.dist/pillars/vhosts.sls.dist
+++ b/salt.dist/pillars/vhosts.sls.dist
@@ -1,9 +1,11 @@
+{% set php_version = '7.3' %}
 vhosting:
   users:
     project:
       vhost:
         projectname-dev.enrise.com:
           webroot_public: True
+          php_version: '{{ php_version }}'
           fastcgi_params:
             - fastcgi_param APPLICATION_ENV development;
           extra_config:

--- a/salt.dist/states/custom.sls.dist
+++ b/salt.dist/states/custom.sls.dist
@@ -1,0 +1,12 @@
+{% set php_version = '7.3' %}
+extend:
+  /srv/http/project/hosts/projectname-dev.enrise.com:
+    file.symlink:
+      - target: ../current
+      - owner: vagrant
+      - group: vagrant
+      - require:
+        - file: /srv/http/project/hosts
+      - watch_in:
+        - service: nginx
+        - service: php{{ php_version }}-fpm


### PR DESCRIPTION
Modernized the basebox:
* Use `bento/ubuntu-18.04` instead of `ubuntu/trusty64`
* Provide sample for installing multiple PHP versions / non-ZS setup.