### PR TITLE
Pin salt to 3003

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,10 +20,9 @@ $salt_highstate           ||= true
 $salt_custom_path         ||= 'dev/salt'
 $salt_log_level           ||= 'info'
 $salt_verbose             ||= true
-$salt_version             ||= 'stable'
+$salt_version             ||= 'stable 3003'
 $salt_bootstrap_options   ||= '-P -X -x python3.6'
 $salt_install_args        ||= ''
-$salt_version             ||= 'stable 3003'
 
 # Include Vagrantfile.local if it exists to overwrite the variables.
 eval File.read('Vagrantfile.local') if File.exist?('Vagrantfile.local')

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,7 @@ $salt_verbose             ||= true
 $salt_version             ||= 'stable'
 $salt_bootstrap_options   ||= '-P -X -x python3.6'
 $salt_install_args        ||= ''
+$salt_version             ||= 'stable 3003'
 
 # Include Vagrantfile.local if it exists to overwrite the variables.
 eval File.read('Vagrantfile.local') if File.exist?('Vagrantfile.local')


### PR DESCRIPTION
The new salt version 3004 has a new execution mode which breaks most of the Enrise formula's.